### PR TITLE
Saving records to multiple .pkl files

### DIFF
--- a/bert_prepro.py
+++ b/bert_prepro.py
@@ -1,0 +1,260 @@
+import random
+from tqdm import tqdm
+import spacy
+import ujson as json
+from collections import Counter
+import numpy as np
+import os.path
+import argparse
+import torch
+import torch
+import os
+from joblib import Parallel, delayed
+from util import normalize_answer
+import torch
+import bisect
+import re
+from transformers import BertTokenizer
+
+tokenizer = BertTokenizer.from_pretrained('bert-large-cased', return_token_type_ids=True)
+
+
+def find_nearest(a, target, test_func=lambda x: True):
+    idx = bisect.bisect_left(a, target)
+    if (0 <= idx < len(a)) and a[idx] == target:
+        return idx, 0
+    elif idx == 0:
+        return 0, abs(a[0] - target)
+    elif idx == len(a):
+        return idx - 1, abs(a[-1] - target)
+    else:
+        d1 = abs(a[idx] - target) if test_func(a[idx]) else 1e200
+        d2 = abs(a[idx-1] - target) if test_func(a[idx-1]) else 1e200
+        if d1 > d2:
+            return idx-1, d2
+        else:
+            return idx, d1
+
+
+def fix_span(parastr, offsets, span):
+    span = span.strip()
+    assert span in parastr, '{}\t{}'.format(span, parastr)
+    begins, ends = map(list, zip(*[x for x in offsets]))
+
+    best_dist = 1e200
+    best_indices = None
+
+    if span == parastr:
+        return parastr, (0, len(parastr)), 0
+
+    for m in re.finditer(re.escape(span), parastr):
+        begin_offset, end_offset = m.span()
+        fixed_begin, d1 = find_nearest(begins, begin_offset, lambda x: x < end_offset)
+        fixed_end, d2 = find_nearest(ends, end_offset, lambda x: x > begin_offset)
+        if d1 + d2 < best_dist:
+            best_dist = d1 + d2
+            best_indices = (fixed_begin, fixed_end)
+            if best_dist == 0:
+                break
+
+    assert best_indices is not None
+    return best_indices, best_dist
+
+
+def convert_idx(text, tokens, filter=lambda x: x):
+    current = 0
+    spans = []
+    for token in tokens:
+        if token == '[UNK]':
+            token = ''
+        clear_token = filter(token)
+        current = text.find(clear_token, current)
+        if current < 0:
+            print(token, clear_token, text)
+            raise Exception()
+        spans.append((current, current + len(clear_token)))
+        current += len(clear_token)
+    return spans
+
+
+def tokenize(sent):
+    """
+    :param sent: (str) sentence in natural language
+    :return: (list of str) list of tokens
+    """
+    return tokenizer.tokenize(sent)
+
+
+def filter(token):
+    """
+    :param token: (str) word or part of word after tokenization
+    :return: (str) token as a word or part of word (whithout extra chars)
+    """
+    symbols = '#' #chars that need to be filtered out (e. g. '#' for BERT-like tokenization)
+    return token.lstrip(symbols)
+
+
+def encode(question, context, config):
+    """
+    :param question: (str) question in nl
+    :param context: (str) the whole context concatenated
+    :return: BERT-like tokenization (with special tokens: [CLS] question [SEP] context [SEP])
+    """
+    encoding = tokenizer.encode_plus(question, context, padding='max_length',
+                                     max_length=config.para_limit + config.ques_limit + 3,  is_pretokenized=True)  # cls + 2 * sep
+    return encoding["input_ids"], encoding["attention_mask"]
+
+
+
+def _process_article(article, config):
+    """
+    :param article: dict corresponding to a single qa pair
+    article.keys(): 'supporting_facts' (list of lists), 'level' (str 'easy', 'medium', 'hard'), 'question' (str),
+    'context' (list of lists [title (str), list of sentences (str)], 'answer' (str),  '_id' (str), 'type' (str e.g. 'comparison', 'bridge')
+    :param config: class with training params as fields
+    :return: dicts with features for train and eval
+    """
+    paragraphs = article['context']
+    # some articles in the fullwiki dev/test sets have zero paragraphs
+    if len(paragraphs) == 0:
+        paragraphs = [['some random title', ['some random stuff']]]
+
+    text_context, context_tokens = '', []
+    flat_offsets = []
+
+    def _process(sent):
+        sent = " " + sent + " "
+        nonlocal text_context, context_tokens, flat_offsets
+        N_chars = len(text_context)
+        sent_tokens = tokenize(sent)
+        sent_spans = convert_idx(sent, sent_tokens, filter)
+
+        sent_spans = [[N_chars+e[0], N_chars+e[1]] for e in sent_spans]
+        text_context += sent
+        context_tokens.extend(sent_tokens)
+        flat_offsets.extend(sent_spans)
+
+    for para in paragraphs:
+        cur_title, cur_para = para[0], para[1]
+        _process(cur_title)
+        for sent in cur_para:
+            _process(sent)
+    if 'answer' in article:
+        answer = article['answer'].strip()
+        if answer.lower() == 'yes':
+            best_indices = [-1, -1]
+        elif answer.lower() == 'no':
+            best_indices = [-2, -2]
+        else:
+            if answer not in text_context:
+                # in the fullwiki setting, the answer might not have been retrieved
+                # use (0, 1) so that we can proceed
+                best_indices = (1, 0)
+            else:
+                best_indices, _ = fix_span(text_context, flat_offsets, article['answer'])
+    else:
+        # some random stuff
+        answer = 'random'
+        best_indices = (1, 0)
+    example = {'context' : text_context, 'question' : article['question'],
+               'context_tokens': context_tokens, 'question_tokens': tokenize(article['question']),
+               'y1s': best_indices[0], 'y2s': best_indices[1] + 1, 'id': article['_id']}
+    eval_example = {'context': text_context, 'spans': flat_offsets, 'answer': [answer], 'id': article['_id']}
+    return example, eval_example
+
+
+def process_file(filename, config):
+    data = json.load(open(filename, 'r'))
+
+    eval_examples = {}
+
+    outputs = Parallel(n_jobs=12, verbose=10)(delayed(_process_article)(article, config) for article in data)
+    examples = [e[0] for e in outputs]
+    for _, e in outputs:
+        if e is not None:
+            eval_examples[e['id']] = e
+
+    random.shuffle(examples)
+    print("{} questions in total".format(len(examples)))
+
+    return examples, eval_examples
+
+
+def build_features(config, examples, data_type, out_file):
+    if data_type == 'test':
+        para_limit, ques_limit = 0, 0
+        for example in tqdm(examples):
+            para_limit = max(para_limit, len(example['context_tokens']))
+            ques_limit = max(ques_limit, len(example['ques_tokens']))
+    else:
+        para_limit = config.para_limit
+        ques_limit = config.ques_limit
+
+    def filter_func(example):
+        return len(example["context_tokens"]) > para_limit or len(example["question_tokens"]) > ques_limit
+
+    print("Processing {} examples...".format(data_type))
+    datapoints = []
+    total = 0
+    total_ = 0
+    for example in tqdm(examples):
+        total_ += 1
+
+        if filter_func(example):
+            continue
+
+        total += 1
+
+        input_ids, attention_mask = encode(example['question'], example['context'], config)
+        question_shift = len(example['question_tokens']) + 2  # cls + question + sep
+        # answer span is based on context_text tokens only but after encoding
+        #  question and special tokens are added in front
+
+        start, end = example["y1s"], example["y2s"]
+        y1, y2 = start + question_shift, end + question_shift
+
+        datapoints.append(
+            {'input_ids': input_ids, 'attention_mask': attention_mask,
+            'y1': y1, 'y2': y2, 'id': example['id']}
+        )
+    print("Build {} / {} instances of features in total".format(total, total_))
+    dir_name = data_type
+    try:
+        os.mkdir(dir_name)
+        print(f"Directory {dir_name} created")
+    except OSError:
+        print(f"Directory {dir_name} already exists, writing files there")
+    fileparts = out_file.split('.')
+    name, ext = '.'.join(fileparts[:-1]), fileparts[-1]  # separating file into name and extention
+    num_objects = len(datapoints)
+    num_files = config.num_files if config.num_files > 0 else num_objects
+    batch_size = num_objects // num_files
+    for i in range(num_files - 1):
+        torch.save(datapoints[i * batch_size: (i + 1) * batch_size], f'{dir_name}/{name}_{str(i)}.{ext}')
+    torch.save(datapoints[(num_files - 1) * batch_size:], f'{dir_name}/{name}_{str(num_files - 1)}.{ext}')
+
+
+def save(filename, obj, message=None):
+    if message is not None:
+        print("Saving {}...".format(message))
+    with open(filename, "w") as fh:
+        json.dump(obj, fh)
+
+
+def prepro(config):
+    random.seed(13)
+    examples, eval_examples = process_file(config.data_file, config)
+
+    if config.data_split == 'train':
+        record_file = config.train_record_file
+        eval_file = config.train_eval_file
+    elif config.data_split == 'dev':
+        record_file = config.dev_record_file
+        eval_file = config.dev_eval_file
+    elif config.data_split == 'test':
+        record_file = config.test_record_file
+        eval_file = config.test_eval_file
+
+    build_features(config, examples, config.data_split, record_file)
+    save(eval_file, eval_examples, message='{} eval'.format(config.data_split))
+

--- a/bert_prepro.py
+++ b/bert_prepro.py
@@ -3,12 +3,12 @@ from tqdm import tqdm
 import spacy
 import ujson as json
 import jsonlines
+import pickle
 import collections
 from collections import Counter
 import numpy as np
 import os.path
 import argparse
-import torch
 import torch
 import os
 from joblib import Parallel, delayed
@@ -19,6 +19,7 @@ import re
 import string
 import copy
 from transformers import BertTokenizer
+import shutil
 
 BERT_MAX_SEQ_LEN = 512
 tokenizer = BertTokenizer.from_pretrained('bert-large-cased', return_token_type_ids=True)
@@ -107,7 +108,7 @@ def remove_punctuation(sent):
     return re.sub('[%s]' % re.escape(string.punctuation), '', sent)
 
 def preprocess(sent):
-    return sent
+    return sent.encode('latin-1', 'ignore').decode('latin-1')
 
 def encode(question, context, max_length, config):
     """
@@ -171,22 +172,19 @@ def _process_article(article, config):
     is_answerable = True
     is_yes_no = False
     yes_no = None  # 0 if 'no', 1 otherwise
-    if 'answer' in article:
+    
+    if 'answer' in article.keys():
+        best_indices = [0, 0]
         answer = preprocess(article['answer'].strip())
-        if answer.lower() == 'yes':
-            best_indices = [-2, -2]
+        if answer.lower() in ['yes', 'no']:
             is_yes_no = True
-            yes_no = 1
-        elif answer.lower() == 'no':
-            best_indices = [-1, -1]
-            is_yes_no = True
-            yes_no = 1
+            answer = answer.lower()
+            yes_no = int(answer == 'yes')
         else:
             if answer not in text_context:
                 # in the fullwiki setting, the answer might not have been retrieved
                 # use (0, 1) so that we can proceed
                 answer = ''
-                best_indices = [0, 0]
                 is_answerable = False
             else:
                 best_indices, _ = fix_span(text_context, flat_offsets, answer)
@@ -214,6 +212,7 @@ def process_file(filename, config):
     outputs = Parallel(n_jobs=12, verbose=10)(delayed(_process_article)(article, config) for article in data)
     examples = [e[0] for e in outputs]
     eval_examples = [e[1] for e in outputs]
+
     random.shuffle(examples)
     print("{} questions in total".format(len(examples)))
 
@@ -267,6 +266,17 @@ def build_features(config, examples, data_type, out_file):
     doc_stride = config.doc_stride
     
     unique_id = 0
+
+    unanswerable_count = 0
+    yes_no_count = 0
+    span_count = 0
+    total_count = 0
+
+    unanswerable_ex_count = 0
+    yes_no_ex_count = 0
+    span_ex_count = 0
+    total_ex_count = len(examples)
+    max_chunks = 0
     for example in tqdm(examples):
         question_tokens = example['question_tokens']
         context_tokens = example['context_tokens']
@@ -295,11 +305,17 @@ def build_features(config, examples, data_type, out_file):
             if start_offset + length == len(context_tokens):
                 break
             start_offset += min(length, doc_stride)
-
+       
         is_answerable_example = example['is_answerable']
         is_yes_no_example = example['is_yes_no']
         yes_no_example = example['yes_no']
+
+        unanswerable_ex_count += (1 - is_answerable_example)
+        yes_no_ex_count += is_yes_no_example
+        span_ex_count += (1 - is_yes_no_example) * is_answerable_example
+
         supportive_facts = example['start_end_facts']
+        max_chunks = max(max_chunks, len(doc_spans))
         for (doc_span_index, doc_span) in enumerate(doc_spans):
             tokens = []
             segment_ids = []
@@ -347,10 +363,10 @@ def build_features(config, examples, data_type, out_file):
             doc_start = doc_span.start
             doc_end = doc_span.start + doc_span.length - 1
 
-            y1, y2 = None, None
+            y1, y2 = 0, 0
             is_answerable = 0
-            # yes -- 1, no -- 0
             is_yes_no = 0
+            # yes -- 1, no -- 0
             yes_no = 0
             answer_options = [1, 0]
             if config.is_training:
@@ -361,42 +377,105 @@ def build_features(config, examples, data_type, out_file):
                     y1 = start - doc_start + question_shift
                     y2 = end - doc_start + question_shift
                     is_answerable = 1
-                elif is_yes_no:
+                if is_yes_no_example:
+                    is_yes_no = 1
                     for s, e, sup in supportive_facts:
                         if sup and (s >= doc_start and e <= doc_end):
                             is_answerable = 1
-                            is_yes_no = 1
                             yes_no = answer_options[start]
                             y1, y2 = start, end
                             break
                     else:
                         y1, y2 = 0, 0
+                yes_no_count += is_yes_no
+                span_count += is_answerable * (1 - is_yes_no)
+                unanswerable_count += (1 - is_answerable)
+                total_count += 1
+            labels = [is_answerable, is_yes_no, yes_no, y1, y2]
             datapoints.append({'input_ids': input_ids, 'attention_mask': input_mask, 'token_type_ids': segment_ids,
-                               'max_context': max_context,
-                               'is_yes_no': is_yes_no, 'is_answerable': is_answerable, 'yes_no': yes_no,
-                               'y1': y1, 'y2': y2, 'example_id': example['id'], 'feature_id': unique_id})
+                               'max_context': max_context, 'feature_id': unique_id, 'example_id': example['id'],
+                               'labels' : labels})
             unique_id += 1
+
+    print(f'max chunks: {max_chunks}')
+    print(f"unanswerable: {unanswerable_count / total_count}, yes_no: {yes_no_count / total_count}, span: {span_count / total_count}")
+    print(f"unansweravle examples: {unanswerable_ex_count}, yes_no_examples: {yes_no_ex_count}, span: {span_ex_count}")
+
+    yes_no_examples = []
+    for datapoint in datapoints:
+        is_y_n = datapoint['labels'][1]
+        ex_id = datapoint['example_id']
+        if is_y_n:
+            yes_no_examples.append(ex_id)
+    print(f'YES NO EXAMPLES IN THE DATA: {len(set(yes_no_examples))}')
 
     dir_name = data_type
     try:
         os.mkdir(dir_name)
         print(f"Directory {dir_name} created")
     except OSError:
-        print(f"Directory {dir_name} already exists, writing files there")
-
+        print(f"Removing directory {dir_name} and creating a new one")
+        shutil.rmtree(dir_name)
+        os.mkdir(dir_name)
     fileparts = out_file.split('.')
     name, ext = '.'.join(fileparts[:-1]), fileparts[-1]
     num_objects = len(datapoints)
     num_files = config.num_files if config.num_files > 0 else num_objects
     batch_size = num_objects // num_files
-    for i in range(num_files - 1):
-        with jsonlines.open(f'{dir_name}/{name}_{str(i)}.{ext}', mode='w') as writer:
-            for datapoint in datapoints[i * batch_size: (i + 1) * batch_size]:
-                writer.write(datapoint)
-    with jsonlines.open(f'{dir_name}/{name}_{str(num_files - 1)}.{ext}', mode='w') as writer:
-        for datapoint in datapoints[(num_files - 1) * batch_size:]:
-            writer.write(datapoint)
+    st = 0
+    # dividing datapoints between mltiple files for using lazy dataloading with multiple workers
+    # files are supposed to be of approximately equal size, but we do not want to split examples between files
 
+    examples_total = 0
+    for i in range(num_files - 1):
+        examples = [] # holds starting and ending lines of the examples in the respective file
+        start = 0
+        ex_id = None
+        is_y_n = False
+        with jsonlines.open(f'{dir_name}/{name}_{str(i)}.{ext}', mode='w') as writer:
+            for dp_idx, datapoint in enumerate(datapoints[st: (i + 1) * batch_size]):
+                if ex_id and datapoint['example_id'] != ex_id:
+                    end = dp_idx
+                    if is_y_n:
+                        examples.append((start, end))
+                    start = end
+                ex_id = datapoint['example_id']
+                is_y_n = datapoint['labels'][1]
+                writer.write(datapoint)
+            last_ex_id = datapoints[(i + 1) * batch_size - 1]['example_id']
+            j = (i + 1) * batch_size
+            while datapoints[j]['example_id'] == last_ex_id:
+                writer.write(datapoints[j])
+                j += 1
+            if is_y_n:
+                examples.append((start, j - st))
+            st = j
+        examples_total += len(examples)
+        with open(f'{dir_name}/{name}_{str(i)}_meta.pickle', mode='wb') as fp:
+            pickle.dump(examples, fp)
+    
+    examples = [] # holds starting and ending lines of the examples in the respective file
+    start = 0
+    ex_id = None
+    is_y_n = False
+
+    with jsonlines.open(f'{dir_name}/{name}_{str(num_files - 1)}.{ext}', mode='w') as writer:
+        for dp_idx, datapoint in enumerate(datapoints[st:]):
+            if ex_id and datapoint['example_id'] != ex_id:
+                end = dp_idx
+                if is_y_n:
+                    examples.append((start, end))
+                start = end
+            ex_id = datapoint['example_id']
+            is_y_n = datapoint['labels'][1]
+            writer.write(datapoint)
+        end = dp_idx
+        if is_y_n:
+            examples.append((start, end))
+    examples_total += len(examples)
+    print(f'EXAMPLES IN THE DATASET: {examples_total}')
+    with open(f'{dir_name}/{name}_{str(num_files - 1)}_meta.pickle', mode='wb') as fp:
+        pickle.dump(examples, fp)
 
 def save(filename, obj, message=None):
     if message is not None:
@@ -409,6 +488,7 @@ def prepro(config):
     random.seed(13)
     examples, eval_examples = process_file(config.data_file, config)
 
+    print(len(examples), len(eval_examples))
     if config.data_split == 'train':
         record_file = config.train_record_file
         eval_file = config.train_eval_file
@@ -420,6 +500,5 @@ def prepro(config):
         eval_file = config.test_eval_file
 
     build_features(config, examples, config.data_split, record_file)
-    if config.data_split in ['dev', 'test']:
-        save(eval_file, eval_examples, message='{} eval'.format(config.data_split))
+    save(eval_file, eval_examples, message='{} eval'.format(config.data_split))
 

--- a/download.sh
+++ b/download.sh
@@ -5,10 +5,10 @@ wget http://curtis.ml.cmu.edu/datasets/hotpot/hotpot_dev_fullwiki_v1.json
 wget http://curtis.ml.cmu.edu/datasets/hotpot/hotpot_train_v1.1.json
 
 # Download GloVe
-GLOVE_DIR=./
-mkdir -p $GLOVE_DIR
-wget http://nlp.stanford.edu/data/glove.840B.300d.zip -O $GLOVE_DIR/glove.840B.300d.zip
-unzip $GLOVE_DIR/glove.840B.300d.zip -d $GLOVE_DIR
+#GLOVE_DIR=./
+#mkdir -p $GLOVE_DIR
+#wget http://nlp.stanford.edu/data/glove.840B.300d.zip -O $GLOVE_DIR/glove.840B.300d.zip
+#unzip $GLOVE_DIR/glove.840B.300d.zip -d $GLOVE_DIR
 
 # Download Spacy language models
 python3 -m spacy download en

--- a/main.py
+++ b/main.py
@@ -67,16 +67,16 @@ parser.add_argument('--fullwiki', action='store_true')
 parser.add_argument('--prediction_file', type=str)
 parser.add_argument('--sp_threshold', type=float, default=0.3)
 
+parser.add_argument('--num_files', type=int, default=1)
+
 config = parser.parse_args()
 
 def _concat(filename):
     if config.fullwiki:
         return 'fullwiki.{}'.format(filename)
     return filename
-# config.train_record_file = _concat(config.train_record_file)
 config.dev_record_file = _concat(config.dev_record_file)
 config.test_record_file = _concat(config.test_record_file)
-# config.train_eval_file = _concat(config.train_eval_file)
 config.dev_eval_file = _concat(config.dev_eval_file)
 config.test_eval_file = _concat(config.test_eval_file)
 

--- a/main.py
+++ b/main.py
@@ -17,9 +17,9 @@ word2idx_file = "word2idx.json"
 char2idx_file = "char2idx.json"
 idx2word_file = 'idx2word.json'
 idx2char_file = 'idx2char.json'
-train_record_file = 'train_record.pkl'
-dev_record_file = 'dev_record.pkl'
-test_record_file = 'test_record.pkl'
+train_record_file = 'train_record.jsonl'
+dev_record_file = 'dev_record.jsonl'
+test_record_file = 'test_record.jsonl'
 
 
 parser.add_argument('--mode', type=str, default='train')
@@ -70,7 +70,10 @@ parser.add_argument('--sp_threshold', type=float, default=0.3)
 
 parser.add_argument('--num_files', type=int, default=1)
 parser.add_argument('--tokenizer', type=str, default='spacy')
-
+parser.add_argument('--doc_stride', type=int, default=128)
+parser.add_argument('--is_training', type=bool, default=True)
+parser.add_argument('--max_query_length', type=int, default=75)
+parser.add_argument('--max_seq_length', type=int, default=512)
 
 config = parser.parse_args()
 

--- a/main.py
+++ b/main.py
@@ -20,6 +20,8 @@ idx2char_file = 'idx2char.json'
 train_record_file = 'train_record.jsonl'
 dev_record_file = 'dev_record.jsonl'
 test_record_file = 'test_record.jsonl'
+yes_no_example_file = 'yn_id_to_ans.pickle'
+
 
 
 parser.add_argument('--mode', type=str, default='train')
@@ -40,6 +42,8 @@ parser.add_argument('--idx2char_file', type=str, default=idx2char_file)
 parser.add_argument('--train_record_file', type=str, default=train_record_file)
 parser.add_argument('--dev_record_file', type=str, default=dev_record_file)
 parser.add_argument('--test_record_file', type=str, default=test_record_file)
+
+parser.add_argument('--yes_no_example_file', type=str, default=yes_no_example_file)
 
 parser.add_argument('--glove_char_size', type=int, default=94)
 parser.add_argument('--glove_word_size', type=int, default=int(2.2e6))
@@ -74,17 +78,24 @@ parser.add_argument('--doc_stride', type=int, default=128)
 parser.add_argument('--is_training', type=bool, default=True)
 parser.add_argument('--max_query_length', type=int, default=75)
 parser.add_argument('--max_seq_length', type=int, default=512)
+parser.add_argument('--level', type=str, default='paragraph')
 
 config = parser.parse_args()
 
-def _concat(filename):
+def _concat(config, filename):
+    new_name = filename
+    #new_name = '{}_{}'.format(config.level, filename)
     if config.fullwiki:
-        return 'fullwiki.{}'.format(filename)
-    return filename
-config.dev_record_file = _concat(config.dev_record_file)
-config.test_record_file = _concat(config.test_record_file)
-config.dev_eval_file = _concat(config.dev_eval_file)
-config.test_eval_file = _concat(config.test_eval_file)
+        new_name = 'fullwiki.{}'.format(new_name)
+    return new_name
+
+config.train_record_file = _concat(config, config.train_record_file)
+config.dev_record_file = _concat(config, config.dev_record_file)
+config.test_record_file = _concat(config, config.test_record_file)
+config.dev_eval_file = _concat(config, config.dev_eval_file)
+config.test_eval_file = _concat(config, config.test_eval_file)
+
+print(config.dev_record_file)
 
 if config.mode == 'train':
     train(config)

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import os
 from prepro import prepro
+from bert_prepro import prepro as BERT_prepro
 from run import train, test
 import argparse
 
@@ -68,6 +69,8 @@ parser.add_argument('--prediction_file', type=str)
 parser.add_argument('--sp_threshold', type=float, default=0.3)
 
 parser.add_argument('--num_files', type=int, default=1)
+parser.add_argument('--tokenizer', type=str, default='spacy')
+
 
 config = parser.parse_args()
 
@@ -83,7 +86,10 @@ config.test_eval_file = _concat(config.test_eval_file)
 if config.mode == 'train':
     train(config)
 elif config.mode == 'prepro':
-    prepro(config)
+    if config.tokenizer == 'spacy':
+        prepro(config)
+    else:
+        BERT_prepro(config)
 elif config.mode == 'test':
     test(config)
 elif config.mode == 'count':

--- a/prepro.py
+++ b/prepro.py
@@ -305,7 +305,7 @@ def build_features(config, examples, data_type, out_file, word2idx_dict, char2id
     fileparts = out_file.split('.')
     name, ext = '.'.join(fileparts[:-1]), fileparts[-1] #separating file into name and extention
     num_objects = len(datapoints)
-    num_files = config.num_files if num_files > 0 else num_objects
+    num_files = config.num_files if config.num_files > 0 else num_objects
     batch_size = num_objects // num_files
     for i in range(num_files - 1):
         torch.save(datapoints[i * batch_size : (i + 1) * batch_size], f'{dir_name}/{name}_{str(i)}.{ext}')

--- a/prepro.py
+++ b/prepro.py
@@ -143,6 +143,7 @@ def _process_article(article, config):
                 # in the fullwiki setting, the answer might not have been retrieved
                 # use (0, 1) so that we can proceed
                 best_indices = (0, 1)
+                print('UNANSWERABLE EXAMPLE:', article['_id'])
             else:
                 _, best_indices, _ = fix_span(text_context, offsets, article['answer'])
                 answer_span = []
@@ -154,6 +155,7 @@ def _process_article(article, config):
         # some random stuff
         answer = 'random'
         best_indices = (0, 1)
+        print('UNANSWERABLE EXAMPLE:', article['_id'])
 
     ques_tokens = word_tokenize(prepro_sent(article['question']))
     ques_chars = [list(token) for token in ques_tokens]
@@ -319,13 +321,14 @@ def save(filename, obj, message=None):
 
 def prepro(config):
     random.seed(13)
-
+    print('NO BERT PREPRO')
     if config.data_split == 'train':
         word_counter, char_counter = Counter(), Counter()
         examples, eval_examples = process_file(config.data_file, config, word_counter, char_counter)
     else:
         examples, eval_examples = process_file(config.data_file, config)
 
+    return 
     word2idx_dict = None
     if os.path.isfile(config.word2idx_file):
         with open(config.word2idx_file, "r") as fh:


### PR DESCRIPTION
argument --num_files added in main.py: if 1 (default value) saves datapoints (object wise) to 1 file (.pkl), if -1 makes as many .pkl files as objects,  if n > 1, saves to n almost equally sized files (last one can differ in size). 
That makes the dataset compatible with custom PyTorch Dataset and library PyTorch Generator (https://stackoverflow.com/questions/54571377/how-to-create-a-custom-pytorch-dataset-when-the-order-and-the-total-number-of-tr/54572327#54572327). 
The files are saved to data_split ("train" or "dev") directory, which is created if not there already, and filenames are the same but with the batch number in the end (e. g. train/train_record_50.pkl)